### PR TITLE
Check to ensure everything is deleted before continuing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk update && apk add curl bash coreutils
+RUN apk update && apk add curl bash coreutils jq
 
 # Get kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+DOCKER ?= docker
+ORG = USERNAME
+BINARY = istio-1.5-migration
+TAG ?= dev
+
+# This build step is not used in CI Pipeline, only for development purposes
+.PHONY: build
+build:
+	$(DOCKER) build -t $(ORG)/$(BINARY):$(TAG) .

--- a/istio-onefive-migration.sh
+++ b/istio-onefive-migration.sh
@@ -28,14 +28,48 @@ users:
 " > sa.kubeconfig
 kubectl config --kubeconfig=sa.kubeconfig use-context default-context
 
-versions=$(kubectl get --ignore-not-found=true deploy istio-galley -n istio-system  -o=jsonpath='{$.spec.template.spec.containers[*].image}')
+# purposely not checking galley deploy here in case the job is terminated and reruns
+versions=$(kubectl get --ignore-not-found=true deploy istio-pilot -n istio-system  -o=jsonpath='{$.spec.template.spec.containers[*].image}')
 if [[ $versions == *"1.4"* || $versions == *"1.3"* ]]; then
 	echo "Preparing for migration to Istio 1.5"
-	kubectl delete --wait=true --timeout=20s --ignore-not-found=true deployment istio-galley -n istio-system
-	kubectl delete --wait=true --timeout=20s --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io istio-galley
-	kubectl delete --wait=true --timeout=20s --ignore-not-found=true serviceaccount istio-reader-service-account -n istio-system
-	kubectl delete --wait=true --timeout=20s --ignore-not-found=true clusterrolebinding istio-reader
-	sleep 2 # ensure webhook is gone or we get conflict errors
-fi
 
-echo "Istio 1.4 cleanup complete"
+  echo "Deleting galley deployment"
+	kubectl delete --wait=true --timeout=20s --ignore-not-found=true deployment istio-galley -n istio-system
+  c=0
+  while [ "$(kubectl get pods --selector=app=galley -n istio-system --output json | jq -j '.items | length')" != "0" ] && [ $c -lt 20 ]; do
+    echo "waiting for galley pods to terminate..."
+    sleep 6
+    c=$((c+1))
+  done
+
+  echo "Deleting galley validating webhook"
+	kubectl delete --wait=true --timeout=20s --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io istio-galley
+  c=0
+  while [ "$(kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io --field-selector=metadata.name=istio-galley --output json | jq -j '.items | length')" != "0" ] && [ $c -lt 5 ]; do
+    echo "waiting for istio-galley validating webhook to terminate..."
+    sleep 2
+    c=$((c+1))
+  done
+
+  echo "Deleting istio-reader-service-account"
+	kubectl delete --wait=true --timeout=20s --ignore-not-found=true serviceaccount istio-reader-service-account -n istio-system
+  c=0
+  while [ "$(kubectl get serviceaccount -n istio-system --field-selector=metadata.name=istio-reader-service-account --output json | jq -j '.items | length')" != "0" ] && [ $c -lt 5 ]; do
+    echo "waiting for istio-reader-service-account to terminate..."
+    sleep 2
+    c=$((c+1))
+  done
+
+  echo "Deleting clusterrolebinding istio-reader"
+	kubectl delete --wait=true --timeout=20s --ignore-not-found=true clusterrolebinding istio-reader
+  c=0
+  while [ "$(kubectl get clusterrolebinding --field-selector=metadata.name=istio-reader --output json | jq -j '.items | length')" != "0" ] && [ $c -lt 5 ]; do
+    echo "waiting for istio-reader clusterrolebinding to terminate..."
+    sleep 2
+    c=$((c+1))
+  done
+
+  echo "Istio 1.4 cleanup complete"
+else
+  echo "Not a 1.4 migration, nothing to do."
+fi


### PR DESCRIPTION
Still seeing problems on small clusters. The deletion script wasn't taking into account that galley pods can take about a minute to terminate there. Those terminating pods were recreating the validatingWebhook which then clashed with helm again. This fix waits up to 2 minutes for galley pods to terminate, and also ensures other resources are deleted. 